### PR TITLE
fix: Removing incorrectly added fields in the specification

### DIFF
--- a/domains.yaml
+++ b/domains.yaml
@@ -409,10 +409,6 @@ components:
         schema_version:
           format: int64
           type: integer
-        domain_name:
-          type: string
-        environment:
-          type: string
         links:
           $ref: '#/components/schemas/DomainLinks'
           type: object
@@ -424,8 +420,6 @@ components:
       - count
       - total_pages
       - schema_version
-      - domain_name
-      - environment
       - links
       - results
       type: object


### PR DESCRIPTION
- Fields domain_name and environmental out off results session are wrong fields (API doesn't return that fields).