### PR TITLE
[NO-ISSUE] fix: Remove unavailable parameters from Network Lists' schema

### DIFF
--- a/networklist.yaml
+++ b/networklist.yaml
@@ -28,18 +28,6 @@ paths:
           in: query
           schema:
             type: integer
-        - name: page_size
-          in: query
-          schema:
-            type: integer
-        - name: sort
-          in: query
-          schema:
-            type: string
-        - name: order_by
-          in: query
-          schema:
-            type: string
       responses:
         '200':
           description: A list of Network Lists


### PR DESCRIPTION
This removes the parameters order_by, sort and page_size from the Network Lists' schema, due to being absent from the API (even though present in the documentation: https://api.azion.com/#5f4ae1f7-f5f3-44ee-8a50-d955791e6e23).