### PR TITLE
Fix a iDNS content type

### DIFF
--- a/idns.yaml
+++ b/idns.yaml
@@ -24,7 +24,7 @@ paths:
       responses:
         "200":
           content:
-            application/json; version=3:
+            application/json:
               schema:
                 $ref: '#/components/schemas/GetZonesResponse'
           description: Zones collection retrieved


### PR DESCRIPTION
Trying to use Python SDK I've got this error:

<img width="1361" alt="image" src="https://github.com/aziontech/azionapi-openapi/assets/55988677/24396278-7f07-44b6-ba9a-55116bc7a12f">


Seems like the yaml definition is wrong, I'm fixing this in order to test a new SDK version.