### PR TITLE
chore: add additionalProperties false on request schemas

### DIFF
--- a/data_streaming.yaml
+++ b/data_streaming.yaml
@@ -53,10 +53,7 @@ paths:
       tags:
         -  Data Streaming
       summary: Create a new data streaming
-      description: |        
-        
-
-        
+      description:
       operationId: CreateNewDataStreaming
       requestBody:
         required: true
@@ -464,7 +461,8 @@ components:
             Note:
              * `Range` - From 0 to 100.
              * `To use:` [Contact the sales team](https://www.azion.com/en/contact-sales/) to activate this feature in your account.
-          
+      additionalProperties: false
+
     StandardDataStreamingPostBody:
       type: object
       properties:
@@ -521,7 +519,8 @@ components:
           description: > 
             Note:
              * Field not used with the rtm_activity data source.
-        
+      additionalProperties: false
+
     CustomDataStreamingPostBody:
       type: object
       properties:
@@ -550,9 +549,8 @@ components:
           type: boolean
           nullable: true
           default: true
-        
-      
-        
+      additionalProperties: false
+
     CreateDataStreamingResponse:
       type: object
       properties:
@@ -1072,4 +1070,3 @@ components:
       description: |
         You must inform a token to auth.
         Usage format: `Token <TOKEN>`
-        

--- a/data_streaming.yaml
+++ b/data_streaming.yaml
@@ -1070,3 +1070,4 @@ components:
       description: |
         You must inform a token to auth.
         Usage format: `Token <TOKEN>`
+

--- a/data_streaming.yaml
+++ b/data_streaming.yaml
@@ -53,7 +53,7 @@ paths:
       tags:
         -  Data Streaming
       summary: Create a new data streaming
-      description:
+      description: Create a new data streaming.
       operationId: CreateNewDataStreaming
       requestBody:
         required: true


### PR DESCRIPTION
This PR is intended to fix the Schemathesis HealthCheck issue caused by using oneOf
- Added additionalProperties flag as false in Request Schemas below:
DataStreamingPostBody
StandardDataStreamingPostBody
CustomDataStreamingPostBody

- Added a description on Post method to fix lint