### PR TITLE
deploy key method

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -55,15 +55,19 @@ jobs:
         with:
           fetch-depth: 0
       
+      - name: Setup SSH for SDK repo
+        run: |
+          mkdir -p ~/.ssh/
+          echo "${{ secrets['REPO_ACCESS_TOKEN_'+matrix.types] }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+        shell: bash
+      
       - name: Checkout SDK repo
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          repository: aziontech/azionapi-${{ matrix.types }}-sdk
-          path: ${{ matrix.types }}
-          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+        run: git clone git@github.com:aziontech/azionapi-${{ matrix.types }}-sdk.git ${{ matrix.types }}
+        shell: bash
 
-      #get all .yaml files which were added/modified
+      # get all .yaml files which were added/modified
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v35
@@ -79,17 +83,15 @@ jobs:
             echo 'go.mod' >> ./${{ matrix.types }}/${removed}/.gitignore
             echo 'go.sum' >> ./${{ matrix.types }}/${removed}/.gitignore
           done
+        shell: bash
 
       - name: push changes
         run: |
           cd ${{ matrix.types }}
-          git config user.email "patrick.menoti@gmail.com"
-          git config user.name "PatrickMenoti"
-          git checkout -b generated-sdk
+          git config user.name 'GitHubActionBot'
+          git config user.email 'github-action@users.noreply.github.com'
           git add .
           git commit -m "Auto-Generated SDK"
-          git push origin generated-sdk
-          gh pr create --body "Auto-generated SDK" --title "Auto-generated SDK"
-        env:
-          GH_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
-        
+          git push origin main
+        shell: bash
+      


### PR DESCRIPTION
Change the SDK generation deploy method to use deploy keys in order to auto-merge the resulting code on the SDK repos.