### PR TITLE
chore: Skip trying to push to SDKs if unchanged

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -2,7 +2,8 @@ name: Generate
 
 on:
   push:
-    branches: [ main ]
+    branches:
+    - main
 
 jobs:
   generate_job:
@@ -87,9 +88,13 @@ jobs:
           git config user.name "PatrickMenoti"
           git checkout -b generated-sdk
           git add .
-          git commit -m "Auto-Generated SDK"
-          git push origin generated-sdk
-          gh pr create --body "Auto-generated SDK" --title "Auto-generated SDK"
+          if git diff-index --quiet HEAD --; then
+            echo "::warning::No changes to commit for ${{ matrix.types }}. Skipping opening a PR for it."
+          else
+            git commit -m "Auto-Generated SDK"
+            git push origin generated-sdk
+            gh pr create --body "Auto-generated SDK" --title "Auto-generated SDK"
+          fi
         env:
           GH_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
         


### PR DESCRIPTION
Prevent trying to open a PR in the SDKs repositories if no change is detected in the newly generated SDK files.