### PR TITLE
Ajust-OpenAPI-EdgeApp---type-weight-to-int

### DIFF
--- a/edgeapplications.yaml
+++ b/edgeapplications.yaml
@@ -4667,8 +4667,19 @@ components:
     CreateOriginsRequest_addresses:
       example:
         address: address
+        is_active: true
+        weight: weight
+        server_role: server_role
       properties:
         address:
+          type: string
+        is_active:
+          type: boolean
+        weight:
+          nullable: true
+          type: integer
+          format: int64
+        server_role:
           type: string
       required:
       - address
@@ -4684,7 +4695,7 @@ components:
           type: string
         weight:
           nullable: true
-          type: string
+          type: integer
         server_role:
           type: string
         is_active:


### PR DESCRIPTION
Commit Title: Update CreateOriginsRequest_addresses Schema

Commit Message:

This commit updates the CreateOriginsRequest_addresses schema in the edgeapplications.yaml file to align it with the OriginsResultResponse_addresses schema.

The following changes were made:

1. Added `is_active`, `weight`, and `server_role` properties to the CreateOriginsRequest_addresses schema. These properties are already present in the OriginsResultResponse_addresses schema.

2. Added `format: int64` to the `weight` property to specify that it should be a 64-bit integer.

These changes ensure consistency between the request and response schemas and provide clearer expectations for the API users about what data should be included in the request and what data they can expect in the response.